### PR TITLE
fix: MySQL initialization failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor/
 .env
 *.log
 temp_audio/*
+
+./app_mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MYSQL_USER=application
       - MYSQL_PASSWORD=application
     volumes:
-      - app_mysql:/var/lib/mysql
+      - ./app_mysql:/var/lib/mysql
       - ./docker/confs/mysql/my.cnf:/etc/mysql/my.cnf
 
   pma:


### PR DESCRIPTION
- Updates the volume path in `docker-compose.yml` to include the required leading './'.
- Fixes the issue where MySQL wouldn't start due to an incorrect volume path.
![image](https://github.com/brunofunnie/chorumebot/assets/48372955/812752ce-3010-4109-bf8d-fd4dfc5691ec)
